### PR TITLE
feat: add version flags to binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -19,7 +20,7 @@ COPY . .
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags "-X main.version=${VERSION}" -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -2,6 +2,7 @@
 FROM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -10,7 +11,7 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o gateway ./cmd/gateway
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags "-X main.version=${VERSION}" -o gateway ./cmd/gateway
 
 # Minimal distroless base
 FROM gcr.io/distroless/static:nonroot

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 IMG ?= ghcr.io/hearth-project/hearth:latest
 # YEAR defines the year value used for substituting the YEAR placeholder in the boilerplate header.
 YEAR ?= $(shell date +%Y)
+# VERSION is injected into manager and gateway binaries. Tagged builds use the
+# nearest git tag, while local builds fall back to dev outside a git checkout.
+VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
+LDFLAGS ?= -X main.version=$(VERSION)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -109,8 +113,9 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 ##@ Build
 
 .PHONY: build
-build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+build: manifests generate fmt vet ## Build manager and gateway binaries.
+	go build -ldflags "$(LDFLAGS)" -o bin/manager cmd/main.go
+	go build -ldflags "$(LDFLAGS)" -o bin/gateway ./cmd/gateway
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
@@ -121,7 +126,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build --build-arg VERSION=$(VERSION) -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -131,7 +136,7 @@ GATEWAY_IMG ?= ghcr.io/hearth-project/hearth-gateway:latest
 
 .PHONY: docker-build-gateway
 docker-build-gateway: ## Build the data-plane gateway image.
-	$(CONTAINER_TOOL) build -f Dockerfile.gateway -t ${GATEWAY_IMG} .
+	$(CONTAINER_TOOL) build --build-arg VERSION=$(VERSION) -f Dockerfile.gateway -t ${GATEWAY_IMG} .
 
 .PHONY: docker-push-gateway
 docker-push-gateway: ## Push the data-plane gateway image.
@@ -154,7 +159,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name hearth-builder
 	$(CONTAINER_TOOL) buildx use hearth-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg VERSION=$(VERSION) --tag ${IMG} -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm hearth-builder
 	rm Dockerfile.cross
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -18,6 +18,8 @@ limitations under the License.
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -25,7 +27,16 @@ import (
 	"github.com/hearth-project/hearth/internal/gateway"
 )
 
+var version = "dev"
+
 func main() {
+	showVersion := flag.Bool("version", false, "Print version and exit.")
+	flag.Parse()
+	if *showVersion {
+		fmt.Println(version)
+		return
+	}
+
 	cfg := gateway.ConfigFromEnv()
 	if cfg.BackendURL == "" {
 		log.Fatalf("%s is required", gateway.EnvBackendURL)
@@ -41,7 +52,7 @@ func main() {
 		addr = gateway.DefaultListenAddr
 	}
 
-	log.Printf("Hearth gateway listening on %s, backend %s", addr, cfg.BackendURL)
+	log.Printf("Hearth gateway version %s listening on %s, backend %s", version, addr, cfg.BackendURL)
 	if err := http.ListenAndServe(addr, gw.Handler()); err != nil { //nolint:gosec // G114: timeouts handled per-request
 		log.Fatalf("Gateway server failed: %v", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -43,6 +44,7 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+	version  = "dev"
 )
 
 func init() {
@@ -63,7 +65,9 @@ func main() {
 	var enableHTTP2 bool
 	var gatewayImage string
 	var gatewayReplicas int
+	var showVersion bool
 	var tlsOpts []func(*tls.Config)
+	flag.BoolVar(&showVersion, "version", false, "Print version and exit.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -91,6 +95,10 @@ func main() {
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+	if showVersion {
+		fmt.Println(version)
+		return
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -212,7 +220,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("Starting manager")
+	setupLog.Info("Starting manager", "version", version)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "Failed to run manager")
 		os.Exit(1)


### PR DESCRIPTION
**What this does**
Adds a `--version` flag to both Hearth binaries so operators can check the manager or gateway build without starting the normal runtime path.

The manager and gateway now default to `dev`, log their version during normal startup, and receive the build version through `-ldflags "-X main.version=..."`. The Makefile now builds both `bin/manager` and `bin/gateway`, and passes the same version into the manager and gateway Docker build paths.

**Related issue**
Closes #4

**Type of change**
- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor / chore

**How it was tested**
- `go build -ldflags "-X main.version=test-version" -o bin/manager cmd/main.go`
- `go build -ldflags "-X main.version=test-version" -o bin/gateway ./cmd/gateway`
- `./bin/manager --version` -> `test-version`
- `./bin/gateway --version` -> `test-version`
- `make build VERSION=test-version LOCALBIN=/tmp/hearth-localbin`
- `make build LOCALBIN=/tmp/hearth-localbin`, then both binaries printed `v0.1.0-rc.1-3-g2f826d6`, matching `git describe --tags --always`
- `make test LOCALBIN=/tmp/hearth-localbin`
- `make lint LOCALBIN=/tmp/hearth-localbin`
- `make lint-config LOCALBIN=/tmp/hearth-localbin`
- `make -n docker-build docker-build-gateway docker-buildx VERSION=test-version LOCALBIN=/tmp/hearth-localbin`

Docker image build/run was not executed locally because the Docker daemon was not running, so I verified the Docker path with the Makefile dry-run output and the Dockerfile build args.

**Checklist**
- [x] `make test` and `make lint` pass
- [x] Regenerated manifests if API/RBAC changed (`make manifests generate && make helm-crds`) — not applicable; no API/RBAC changes
- [x] Tests added/updated (adapters should be golden-tested) — verified with binary smoke checks for the main packages
- [x] Docs/samples updated if needed — not needed for this CLI/build change
- [x] Commits use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:` …)
- [x] All commits are signed off (DCO): `git commit -s` — see below
