### PR TITLE
docs: make LLMService sample storage class neutral

### DIFF
--- a/config/samples/serving_v1alpha1_llmservice.yaml
+++ b/config/samples/serving_v1alpha1_llmservice.yaml
@@ -27,7 +27,8 @@ spec:
   cache:
     strategy: NodeLocalPVC
     size: 60Gi
-    storageClassName: alicloud-disk-essd
+    # Optional: set this for your cluster if you do not want to use the default StorageClass.
+    # storageClassName: <your-rwo-storage-class> # e.g. alicloud-disk-essd
     prewarm: true
   endpoint:
     openAICompatible: true


### PR DESCRIPTION
## Summary

- comment out the Alibaba Cloud-specific `storageClassName` in the sample `LLMService`
- add a cluster-neutral placeholder and guidance to use the default StorageClass unless users need a specific RWO class

Closes #11

## Validation

- `ruby -e 'require "yaml"; doc = YAML.load_file(ARGV.fetch(0)); abort "missing cache" unless doc.dig("spec", "cache"); abort "storageClassName should be commented out" if doc.dig("spec", "cache").key?("storageClassName"); puts "yaml sample ok"' config/samples/serving_v1alpha1_llmservice.yaml`\n- `go test ./api/v1alpha1`\n- `git diff --check`\n\n## Notes\n\nI also attempted `kubectl apply --dry-run=client --validate=false -f config/samples/serving_v1alpha1_llmservice.yaml`, but the local kubeconfig points at an unavailable cluster and kubectl still attempted API discovery.\n\nI attempted `go test ./...`, but the local macOS Data volume ran out of temporary build space while compiling Kubernetes dependencies (`no space left on device`). This PR only changes a sample manifest; the targeted YAML validation above confirms the sample parses and that `storageClassName` is not active by default.