### PR TITLE
docs(chart): populate Helm notes

### DIFF
--- a/charts/hearth/templates/NOTES.txt
+++ b/charts/hearth/templates/NOTES.txt
@@ -1,6 +1,9 @@
-Hearth {{ .Chart.AppVersion }} is installed in namespace "{{ .Release.Namespace }}".
+Hearth release "{{ .Release.Name }}" ({{ .Chart.AppVersion }}) is installed in namespace "{{ .Release.Namespace }}".
 
-The operator is running. It deploys a data-plane gateway per LLMService using:
+Verify the operator deployment:
+  kubectl get deploy -n {{ .Release.Namespace }} {{ include "hearth.fullname" . }}-controller-manager
+
+The operator deploys a data-plane gateway per LLMService using:
   {{ include "hearth.gatewayImage" . }}
 
 Prerequisites for full functionality (Hearth degrades gracefully without them):
@@ -13,9 +16,9 @@ Try it:
   1. Register a backend:
        kubectl apply -f https://raw.githubusercontent.com/hearth-project/hearth/main/config/samples/serving_v1alpha1_inferenceruntime.yaml
   2. Deploy a model:
-       kubectl apply -f https://raw.githubusercontent.com/hearth-project/hearth/main/config/samples/serving_v1alpha1_llmservice.yaml
+       kubectl apply -n {{ .Release.Namespace }} -f https://raw.githubusercontent.com/hearth-project/hearth/main/config/samples/serving_v1alpha1_llmservice.yaml
   3. Watch it:
-       kubectl get llmservice -w
+       kubectl get llmservice -n {{ .Release.Namespace }} -w
 
 Note: serving real tokens requires a node with a supported accelerator
 (e.g. an NVIDIA GPU + device plugin). Without one, the backend stays Pending.


### PR DESCRIPTION
<!-- Thanks for contributing to Hearth! Keep PRs small and focused. -->

**What this does**
Populates the chart's `NOTES.txt` with a release-aware post-install message. It now shows how to verify the controller deployment, reminds users that KEDA is required for scale-to-zero / autoscaling, and gives the sample `kubectl apply` flow for the runtime plus LLMService.

The `InferenceRuntime` sample is left cluster-scoped, while the `LLMService` apply/watch commands include `-n {{ .Release.Namespace }}` because `LLMService` is namespaced.

**Related issue**
Closes #12

**Type of change**
- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Refactor / chore

**How it was tested**
- `helm template hearth charts/hearth`
- `helm lint charts/hearth`
- `helm install hearth charts/hearth --dry-run=client --debug`
- `git diff --check`
- `make LOCALBIN=/tmp/hearth-codex-bin lint`
- `make LOCALBIN=/tmp/hearth-codex-bin test`

**Checklist**
- [x] `make test` and `make lint` pass
- [x] Regenerated manifests if API/RBAC changed (`make manifests generate && make helm-crds`) - N/A, no API/RBAC changes
- [x] Tests added/updated (adapters should be golden-tested) - N/A, chart notes only
- [x] Docs/samples updated if needed
- [x] Commits use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:` ...)
- [x] All commits are signed off (DCO): `git commit -s` - see below

---

By submitting this pull request, I confirm that my contribution is made under the terms of the
**Apache-2.0** license and I agree to the **Developer Certificate of Origin** ([DCO](https://developercertificate.org/)).
Sign off each commit with `git commit -s` (adds a `Signed-off-by:` line).
