### PR TITLE
docs: add observability guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ vendor-neutral across NVIDIA, Ascend, and more.**
 [![CI](https://github.com/hearth-project/hearth/actions/workflows/test.yml/badge.svg)](https://github.com/hearth-project/hearth/actions/workflows/test.yml)
 [![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](ROADMAP.md)
 
-[**Quickstart**](#quickstart) · [**Architecture**](docs/architecture.md) · [**Roadmap**](ROADMAP.md) · [**Contributing**](CONTRIBUTING.md)
+[**Quickstart**](#quickstart) · [**Architecture**](docs/architecture.md) · [**Observability**](docs/observability.md) · [**Roadmap**](ROADMAP.md) · [**Contributing**](CONTRIBUTING.md)
 
 </div>
 
@@ -149,6 +149,9 @@ scaler is a small Hearth gateway that buffers requests during cold start.
 
 📖 See [`docs/architecture.md`](docs/architecture.md) for the components, CRDs, and the full
 scale-to-zero data flow.
+
+See [`docs/observability.md`](docs/observability.md) for the Grafana dashboard import steps and
+gateway metric reference.
 
 ## Roadmap
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 
 - [Architecture](architecture.md) — components, the two CRDs, and the scale-to-zero data flow.
 - [CRD reference](crd-reference.md) — field-by-field `LLMService` spec reference.
+- [Observability](observability.md) — Grafana dashboard import steps and gateway metrics.
 - [Roadmap](../ROADMAP.md) — what's verified, and the prioritized path to production.
 - [Contributing](../CONTRIBUTING.md) — dev setup, the build/test loop, and how to add a backend.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,32 @@
+# Observability
+
+Hearth exposes Prometheus metrics from both the always-on gateway and the selected backend runtime.
+The bundled Grafana dashboard at [`config/grafana/hearth-overview.json`](../config/grafana/hearth-overview.json)
+visualizes queue depth, request outcomes, cold-start wait, and vLLM runtime signals.
+
+## Import the Grafana dashboard
+
+1. Open Grafana and go to **Dashboards** > **New** > **Import**.
+2. Upload or paste [`config/grafana/hearth-overview.json`](../config/grafana/hearth-overview.json).
+3. Select the Prometheus data source for the dashboard's `DS_PROMETHEUS` input.
+4. Import the dashboard.
+
+The dashboard expects Prometheus to scrape Hearth gateway metrics and the backend vLLM `/metrics`
+endpoint. When the Prometheus Operator CRD is installed, Hearth renders a `ServiceMonitor` for each
+`LLMService` that selects both the gateway and backend services with
+`serving.hearth.dev/llmservice=<llmservice-name>` and scrapes their shared `http` port at `/metrics`.
+
+## Gateway metrics
+
+The gateway exports these metrics on `/metrics`:
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `hearth_gateway_pending` | Gauge | none | Requests admitted and waiting or in flight (the scaler's demand signal). |
+| `hearth_gateway_requests_total` | Counter | `code` | Responses by HTTP status code. |
+| `hearth_gateway_rejections_total` | Counter | `reason` | Rejected requests by reason. |
+| `hearth_gateway_activation_wait_seconds` | Histogram | none | Time spent holding a request until the backend was ready. |
+
+`hearth_gateway_rejections_total` uses reasons such as `queue_full`, `cold_start`, and
+`activation_timeout`. The activation wait histogram is exposed with the standard Prometheus
+`_bucket`, `_sum`, and `_count` series.


### PR DESCRIPTION
<!-- Thanks for contributing to Hearth! Keep PRs small and focused. -->

**What this does**
Adds `docs/observability.md` with Grafana dashboard import steps and a gateway metrics reference sourced from `internal/gateway/gateway.go`.

The guide also documents how the optional Prometheus Operator `ServiceMonitor` selects both the gateway and backend services for an `LLMService`, matching `internal/backend/servicemonitor.go`.

**Related issue**
Closes #10

**Type of change**
- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Refactor / chore

**How it was tested**
- `git diff --check`
- `make LOCALBIN=/tmp/hearth-codex-bin lint`
- `make LOCALBIN=/tmp/hearth-codex-bin test`

**Checklist**
- [x] `make test` and `make lint` pass
- [x] Regenerated manifests if API/RBAC changed (`make manifests generate && make helm-crds`) - N/A, no API/RBAC changes
- [x] Tests added/updated (adapters should be golden-tested) - N/A, docs only
- [x] Docs/samples updated if needed
- [x] Commits use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:` ...)
- [x] All commits are signed off (DCO): `git commit -s` - see below

---

By submitting this pull request, I confirm that my contribution is made under the terms of the
**Apache-2.0** license and I agree to the **Developer Certificate of Origin** ([DCO](https://developercertificate.org/)).
Sign off each commit with `git commit -s` (adds a `Signed-off-by:` line).
