### PR TITLE
docs: add HostPath cache sample

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -3,4 +3,5 @@ resources:
 - serving_v1alpha1_inferenceruntime.yaml
 - serving_v1alpha1_inferenceruntime_ascend.yaml
 - serving_v1alpha1_llmservice.yaml
+- serving_v1alpha1_llmservice_hostpath.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/serving_v1alpha1_llmservice_hostpath.yaml
+++ b/config/samples/serving_v1alpha1_llmservice_hostpath.yaml
@@ -1,0 +1,36 @@
+apiVersion: serving.hearth.dev/v1alpha1
+kind: LLMService
+metadata:
+  labels:
+    app.kubernetes.io/name: hearth
+    app.kubernetes.io/managed-by: kustomize
+  name: qwen3-8b-hostpath
+spec:
+  model:
+    source:
+      uri: modelscope://Qwen/Qwen3-8B-Instruct
+  runtime:
+    name: vllm-nvidia
+    argsOverride:
+      - --max-model-len=8192
+      - --gpu-memory-utilization=0.9
+  resources:
+    accelerators: 1
+    cpu: "8"
+    memory: 32Gi
+  scaling:
+    min: 0
+    max: 3
+    metric: queueDepth
+    target: 10
+    activationTimeout: 5m
+  cache:
+    # HostPath creates a node-local cache under /var/lib/hearth/cache/<namespace>-<service>.
+    # Use it on clusters without a dynamic StorageClass; the cache does not move across nodes.
+    strategy: HostPath
+    prewarm: true
+  endpoint:
+    openAICompatible: true
+    coldStart:
+      mode: keepalive
+      heartbeatInterval: 10s

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,3 +77,5 @@ Cold-start cost is dominated by fetching + loading weights, so caching is what m
 usable. v0 supports `HostPath` and `NodeLocalPVC` (with a pinnable `storageClassName`), plus a
 prewarm Job that hydrates weights before first traffic. Node-local caches are per-node today;
 `SharedPVC` (RWX) for multi-node is on the roadmap.
+For clusters without a dynamic StorageClass, see the HostPath sample in
+[`config/samples/serving_v1alpha1_llmservice_hostpath.yaml`](../config/samples/serving_v1alpha1_llmservice_hostpath.yaml).


### PR DESCRIPTION
<!-- Thanks for contributing to Hearth! Keep PRs small and focused. -->

**What this does**
Adds `config/samples/serving_v1alpha1_llmservice_hostpath.yaml` for clusters that do not have a dynamic StorageClass available.

The sample uses a distinct `LLMService` name so it can live in `config/samples/kustomization.yaml` alongside the existing NodeLocalPVC sample. Its cache comment calls out the key HostPath tradeoff: it is node-local and does not move across nodes.

**Related issue**
Closes #7

**Type of change**
- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Refactor / chore

**How it was tested**
- `git diff --check`
- `make LOCALBIN=/tmp/hearth-codex-bin kustomize`
- `/tmp/hearth-codex-bin/kustomize build config/samples`
- `make LOCALBIN=/tmp/hearth-codex-bin lint`
- `make LOCALBIN=/tmp/hearth-codex-bin test`

**Checklist**
- [x] `make test` and `make lint` pass
- [x] Regenerated manifests if API/RBAC changed (`make manifests generate && make helm-crds`) - N/A, no API/RBAC changes
- [x] Tests added/updated (adapters should be golden-tested) - N/A, sample/docs only
- [x] Docs/samples updated if needed
- [x] Commits use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:` ...)
- [x] All commits are signed off (DCO): `git commit -s` - see below

---

By submitting this pull request, I confirm that my contribution is made under the terms of the
**Apache-2.0** license and I agree to the **Developer Certificate of Origin** ([DCO](https://developercertificate.org/)).
Sign off each commit with `git commit -s` (adds a `Signed-off-by:` line).
